### PR TITLE
providing a way to handle success

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,8 @@ if 'canonical' in response:
 
 #Get the list of successfully handled registration_ids
 if 'success' in response:
-    for success, reg_ids in response['success'].items():
-        for reg_id in reg_ids :
-            print 'SUCCESS for reg_id %s' % reg_id
+    for reg_id, success_id in response['success'].items():
+        print 'SUCCESS for reg_id %s' % reg_id
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ if 'canonical' in response:
 
 #Get the list of successfully handled registration_ids
 if 'success' in response:
-    for success, reg_id in response['success'].items():
-        print 'SUCCESS for reg_id %s' % reg_id
+    for success, reg_ids in response['success'].items():
+        for reg_id in reg_ids :
+            print 'SUCCESS for reg_id %s' % reg_id
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ if 'canonical' in response:
         entry = entity.filter(registration_id=reg_id)
         entry.registration_id = canonical_id
         entry.save()
+
+#Get the list of successfully handled registration_ids
+if 'success' in response:
+    for success, reg_id in response['success'].items():
+        print 'SUCCESS for reg_id %s' % reg_id
+
+
 ```
 
 Exceptions

--- a/gcm/gcm.py
+++ b/gcm/gcm.py
@@ -182,12 +182,15 @@ class GCM(object):
     def handle_json_response(self, response, registration_ids):
         errors = group_response(response, registration_ids, 'error')
         canonical = group_response(response, registration_ids, 'registration_id')
+        success = group_response(response, registration_ids, 'message_id')
 
         info = {}
         if errors:
             info.update({'errors': errors})
         if canonical:
             info.update({'canonical': canonical})
+        if success:
+            info.update({'success': success})
 
         return info
 

--- a/gcm/gcm.py
+++ b/gcm/gcm.py
@@ -34,7 +34,7 @@ def group_response(response, registration_ids, key):
     # Only consider the value in the dict
     tupled = [(s[0], s[1][key]) for s in filtered]
     # Grouping of errors and mapping of ids
-    if key is 'registration_id':
+    if key in ['registration_id','message_id']:
         grouping = {}
         for k, v in tupled:
             grouping[k] = v

--- a/gcm/test.py
+++ b/gcm/test.py
@@ -117,9 +117,9 @@ class GCMTest(unittest.TestCase):
         self.assertEqual(canonical_group['5443'], '07645')
 
         success_group = group_response(self.response, ids, 'message_id')
-    	self.assertEqual(success_group['678'], '54749687859')
-		self.assertEqual(success_group['999'], '5456453453')
-		self.assertEqual(success_group['5443'], '123456778')
+        self.assertEqual(success_group['678'], '54749687859')
+        self.assertEqual(success_group['999'], '5456453453')
+        self.assertEqual(success_group['5443'], '123456778')
 
     def test_group_response_no_error(self):
         ids = ['123', '345', '678']
@@ -137,7 +137,7 @@ class GCMTest(unittest.TestCase):
         self.assertEqual(error_group, None)
         self.assertEqual(canonical_group, None)
         for id in ids:
-    		self.assertIn(id,success_group)
+            self.assertIn(id,success_group)
 
     def test_handle_json_response(self):
         ids = ['123', '345', '678', '999', '1919', '5443']
@@ -148,7 +148,7 @@ class GCMTest(unittest.TestCase):
         self.assertIn('canonical', res)
         self.assertIn('678', res['canonical'])
         self.assertIn('678', res['success'])
-    	self.assertNotIn('123', res['success'])
+        self.assertNotIn('123', res['success'])
 
     def test_handle_json_response_no_error(self):
         ids = ['123', '345', '678']

--- a/gcm/test.py
+++ b/gcm/test.py
@@ -116,6 +116,11 @@ class GCMTest(unittest.TestCase):
         self.assertEqual(canonical_group['678'], '6969')
         self.assertEqual(canonical_group['5443'], '07645')
 
+        success_group = group_response(self.response, ids, 'message_id')
+    	self.assertEqual(success_group['678'], '54749687859')
+		self.assertEqual(success_group['999'], '5456453453')
+		self.assertEqual(success_group['5443'], '123456778')
+
     def test_group_response_no_error(self):
         ids = ['123', '345', '678']
         response = {
@@ -127,8 +132,12 @@ class GCMTest(unittest.TestCase):
         }
         error_group = group_response(response, ids, 'error')
         canonical_group = group_response(response, ids, 'registration_id')
+        success_group = group_response(response, ids, 'message_id')
+
         self.assertEqual(error_group, None)
         self.assertEqual(canonical_group, None)
+        for id in ids:
+    		self.assertIn(id,success_group)
 
     def test_handle_json_response(self):
         ids = ['123', '345', '678', '999', '1919', '5443']
@@ -138,6 +147,8 @@ class GCMTest(unittest.TestCase):
         self.assertIn('NotRegistered', res['errors'])
         self.assertIn('canonical', res)
         self.assertIn('678', res['canonical'])
+        self.assertIn('678', res['success'])
+    	self.assertNotIn('123', res['success'])
 
     def test_handle_json_response_no_error(self):
         ids = ['123', '345', '678']
@@ -152,6 +163,7 @@ class GCMTest(unittest.TestCase):
 
         self.assertNotIn('errors', res)
         self.assertNotIn('canonical', res)
+        self.assertIn('success',res)
 
     def test_handle_plaintext_response(self):
         response = 'Error=NotRegistered'


### PR DESCRIPTION
Hi

Here is an improvement to enable the handling of success cases for json_requests.
Here we can now have the list of all registration_ids that were successful.

There is something to keep in mind that i didn't write in the readme (because it's already in GCM manual) : the registration_ids listed in "success" can also be in "canonical"

well.. i hope, because I admit that your "group_response" method is quite obscure to me :)

Guillaume