### PR TITLE
Remove GCMNoCollapseKeyException

### DIFF
--- a/gcm/gcm.py
+++ b/gcm/gcm.py
@@ -13,7 +13,6 @@ class GCMMalformedJsonException(GCMException): pass
 class GCMConnectionException(GCMException): pass
 class GCMAuthenticationException(GCMException): pass
 class GCMTooManyRegIdsException(GCMException): pass
-class GCMNoCollapseKeyException(GCMException): pass
 class GCMInvalidTtlException(GCMException): pass
 
 # Exceptions from Google responses
@@ -80,7 +79,6 @@ class GCM(object):
 
         :return constructed dict or JSON payload
         :raises GCMInvalidTtlException: if time_to_live is invalid
-        :raises GCMNoCollapseKeyException: if collapse_key is missing when time_to_live is used
         """
 
         if time_to_live:
@@ -103,8 +101,6 @@ class GCM(object):
 
         if time_to_live:
             payload['time_to_live'] = time_to_live
-            if collapse_key is None:
-                raise GCMNoCollapseKeyException("collapse_key is required when time_to_live is provided")
 
         if collapse_key:
             payload['collapse_key'] = collapse_key

--- a/gcm/test.py
+++ b/gcm/test.py
@@ -62,10 +62,6 @@ class GCMTest(unittest.TestCase):
         for arg in ['registration_ids', 'data', 'collapse_key', 'delay_while_idle', 'time_to_live']:
             self.assertIn(arg, payload)
 
-    def test_require_collapse_key(self):
-        with self.assertRaises(GCMNoCollapseKeyException):
-            self.gcm.construct_payload(registration_ids='1234', data=self.data, time_to_live=3600)
-
     def test_json_payload(self):
         reg_ids = ['12', '145', '56']
         json_payload = self.gcm.construct_payload(registration_ids=reg_ids, data=self.data)


### PR DESCRIPTION
It turned out that collapse key is not a requirement for messages with
TTL at least since Oct, 2012.

See https://plus.google.com/u/0/104524825852741167674/posts/AEpCusdNZY9
for details.
