### PR TITLE
Fix "TypeError: unhashable type" when calling json_request

### DIFF
--- a/gcm/gcm.py
+++ b/gcm/gcm.py
@@ -271,7 +271,7 @@ class GCM(object):
         for attempt in range(retries):
             payload = self.construct_payload(
                 registration_ids, data, collapse_key,
-                delay_while_idle, time_to_live, dry_run
+                delay_while_idle, time_to_live, True, dry_run
             )
             response = self.make_request(payload, is_json=True)
             info = self.handle_json_response(response, registration_ids)


### PR DESCRIPTION
This bug was introduced as part of #43.

`dry_run` was appended to `construct_payload` parameters.  However, there was a single instance where
`construct_payload` was executed (inside `json_request`) and relying on `is_json` parameter's default value.
