### PR TITLE
We should remove registration ids also when InvalidRegistration coming from GCM

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Error handling
    if 'errors' in response:
        for error, reg_ids in response['errors'].items():
            # Check for errors and act accordingly
-           if error is 'NotRegistered':
+           if error in ['NotRegistered', 'InvalidRegistration']:
                # Remove reg_ids from database
                for reg_id in reg_ids:
                    entity.filter(registration_id=reg_id).delete()


### PR DESCRIPTION
InvalidRegistration error coming as a response from GCM should also be handled to delete the bad registration id.