### PR TITLE
Python-3 compatibility.

### DIFF
--- a/gcm/__init__.py
+++ b/gcm/__init__.py
@@ -1,4 +1,7 @@
-
-import gcm
-
-GCM = gcm.GCM
+try:
+    # Python3; implicit relative imports aren't allowed, so 'gcm' refers to the
+    # top-level package.
+    from gcm.gcm import GCM
+except ImportError:
+    # Python2; 'gcm' refers to the sibling module.
+    from gcm import GCM


### PR DESCRIPTION
This fixes:

* ImportError for top-level __init__.py, because of differing semantics for import in Python 2/3.
* ImportErrors for urllib/urllib2 in gcm.py.  The functionality has been moved into submodules of urllib in Python3.
* String encode & decode errors errors when reading network data, because of the bytes/str split in Python3.  This follows the recommended practice of decoding & encoding at system boundaries.

Tested in both Python2.7.9 and Python3.4.3, and should work under other minor versions in those series; it continues to work under Python2.  My project (and test case) doesn't exercise all of the library, so it's possible there are other Python3 compatibility issues lurking, but I think I got all the obvious ones.