### PR TITLE
Fix time_to_live encode error

### DIFF
--- a/gcm/gcm.py
+++ b/gcm/gcm.py
@@ -149,7 +149,7 @@ class GCM(object):
             payload['delay_while_idle'] = delay_while_idle
 
         if time_to_live:
-            payload['time_to_live'] = time_to_live
+            payload['time_to_live'] = str(time_to_live)
 
         if collapse_key:
             payload['collapse_key'] = collapse_key

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='python-gcm',
-    version='0.1.4',
+    version='0.1.6',
     packages=['gcm'],
     license=open('LICENSE').read(),
     author='Minh Nam Ngo',


### PR DESCRIPTION
If we set time_to_live to string, we have error "Invalid time_to_live value"; if we set it to int, we've got an "int have not an encode...". This commit fix problem.