### PR TITLE
Add restricted_pacakge_name parameter

### DIFF
--- a/gcm/gcm.py
+++ b/gcm/gcm.py
@@ -118,10 +118,6 @@ class GCM(object):
         else:
             self.proxy = proxy
 
-        self.headers = {
-            'Authorization': 'key=%s' % self.api_key,
-        }
-
 
     def construct_payload(self, registration_ids, data=None, collapse_key=None,
         delay_while_idle=False, time_to_live=None, is_json=True, dry_run=False,
@@ -182,14 +178,17 @@ class GCM(object):
 
         # Default Content-Type is
         # application/x-www-form-urlencoded;charset=UTF-8
+        headers = {
+            'Authorization': 'key=%s' % self.api_key,
+        }
         if is_json:
-            self.headers['Content-Type'] = 'application/json'
+            headers['Content-Type'] = 'application/json'
 
         if not is_json:
             data = urlencode_utf8(data)
 
         response = requests.post(
-            self.url, data=data, headers=self.headers,
+            self.url, data=data, headers=headers,
             proxies=self.proxy
         )
         # Successful response

--- a/gcm/test.py
+++ b/gcm/test.py
@@ -188,9 +188,6 @@ class GCMTest(unittest.TestCase):
         self.gcm.make_request(
             {'message': 'test'}, is_json=True
         )
-        self.assertEqual(self.gcm.headers['Content-Type'],
-            'application/json'
-        )
         self.assertTrue(mock_request.return_value.json.called)
 
 


### PR DESCRIPTION
[Docs:](https://developers.google.com/cloud-messaging/server-ref#downstream)

> `restricted_package_name`: This parameter specifies the package name of the application where the registration tokens must match in order to receive the message.

Also (after #60 was merged), when a `json_request` is made, **all** successive requests would be sent with `Content-Type: application/json` headers (even when calling `plaintext_request`) since the header is never cleared anywhere. Rebuilding the headers dict for every request seems like the most robust way to handle this.
