### PR TITLE
Remove unnecessary image from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,3 @@ Read more on response errors `here
 * GCMMessageTooBigException
 * GCMInvalidRegistrationException
 * GCMUnavailableException
-
-.. image:: http://t.qkme.me/35gjhs.jpg
-   :alt: Gotta catch them all


### PR DESCRIPTION
I believe this sexist image should be removed immediately.

If anyone believes there needs to be a "funny image" regarding the list of exceptions feel free to find a Pokemon image that doesn't degrade women.

It should be everyone's responsibility to strive to make the developer community non-discriminatory, one of the reasons there is a huge gender disparity in our industry is because of things like this.