### PR TITLE
Cleaner and more correct shortcut to GCM

### DIFF
--- a/gcm/__init__.py
+++ b/gcm/__init__.py
@@ -1,4 +1,1 @@
-
-import gcm
-
-GCM = gcm.GCM
+from .gcm import GCM


### PR DESCRIPTION
The previous way caused import errors in python3