### PR TITLE
ability to set priority attribute

### DIFF
--- a/gcm/gcm.py
+++ b/gcm/gcm.py
@@ -121,7 +121,7 @@ class GCM(object):
 
     def construct_payload(self, registration_ids, data=None, collapse_key=None,
         delay_while_idle=False, time_to_live=None, is_json=True, dry_run=False,
-        restricted_package_name=None):
+        restricted_package_name=None, priority=None):
         """
         Construct the dictionary mapping of parameters.
         Encodes the dictionary into JSON if for json requests.
@@ -160,6 +160,9 @@ class GCM(object):
 
         if restricted_package_name:
             payload['restricted_package_name'] = restricted_package_name
+
+        if priority:
+            payload['priority'] = priority
 
         if is_json:
             payload = json.dumps(payload)
@@ -262,7 +265,7 @@ class GCM(object):
 
     def plaintext_request(self, registration_id, data=None, collapse_key=None,
                           delay_while_idle=False, time_to_live=None, retries=5,
-                          dry_run=False, restricted_package_name=None):
+                          dry_run=False, restricted_package_name=None, priority=None):
         """
         Makes a plaintext request to GCM servers
 
@@ -284,6 +287,7 @@ class GCM(object):
             is_json=False,
             dry_run=dry_run,
             restricted_package_name=restricted_package_name,
+            priority=priority,
         )
 
         attempt = 0
@@ -302,7 +306,7 @@ class GCM(object):
 
     def json_request(self, registration_ids, data=None, collapse_key=None,
                      delay_while_idle=False, time_to_live=None, retries=5,
-                     dry_run=False, restricted_package_name=None):
+                     dry_run=False, restricted_package_name=None, priority=None):
         """
         Makes a JSON request to GCM servers
 
@@ -328,6 +332,7 @@ class GCM(object):
             is_json=True,
             dry_run=dry_run,
             restricted_package_name=restricted_package_name,
+            priority=priority,
         )
 
         backoff = self.BACKOFF_INITIAL_DELAY

--- a/gcm/test.py
+++ b/gcm/test.py
@@ -77,6 +77,18 @@ class GCMTest(unittest.TestCase):
         for arg in ['registration_ids', 'data', 'collapse_key', 'delay_while_idle', 'time_to_live', 'dry_run']:
             self.assertIn(arg, payload)
 
+        self.assertNotIn('priority', payload)
+
+    def test_construct_payload_with_priority(self):
+        res = self.gcm.construct_payload(
+            registration_ids=['1', '2'], data=self.data, collapse_key='foo',
+            delay_while_idle=True, time_to_live=3600, is_json=True, dry_run=True,
+            priority=10
+        )
+        payload = json.loads(res)
+        for arg in ['registration_ids', 'data', 'collapse_key', 'delay_while_idle', 'time_to_live', 'dry_run', 'priority']:
+            self.assertIn(arg, payload)
+
     def test_json_payload(self):
         reg_ids = ['12', '145', '56']
         json_payload = self.gcm.construct_payload(registration_ids=reg_ids, data=self.data)

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,5 @@ setup(
     keywords='android gcm push notification google cloud messaging',
     install_requires=['requests'],
     tests_require=['mock'],
+    test_suite='gcm.test',
 )


### PR DESCRIPTION
added ability to set priority attribute

references:
https://developers.google.com/cloud-messaging/http-server-ref
https://developers.google.com/cloud-messaging/concept-options?hl=en#setting-the-priority-of-a-message
