### PR TITLE
JsonPayload: Allow to specify JSON encoder

### DIFF
--- a/gcm/gcm.py
+++ b/gcm/gcm.py
@@ -172,7 +172,9 @@ class PlaintextPayload(Payload):
 class JsonPayload(Payload):
     @property
     def body(self):
-        return json.dumps(self.__dict__)
+        data = dict(self.__dict__)
+        json_encoder = data.pop('json_encoder', None)
+        return json.dumps(data, cls=json_encoder)
 
 
 class GCM(object):


### PR DESCRIPTION
Allow to use a non-standard JSON encoder for JSON payload
construction.