### PR TITLE
Added GCM notification section.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,27 @@ Read about `Google Cloud Messaging <https://developers.google.com/cloud-messagin
 
    # Downstream message using JSON request with extra arguments
    res = gcm.json_request(
-       registration_ids=reg_ids, data=data,
-       collapse_key='uptoyou', delay_while_idle=True, time_to_live=3600
+       registration_ids=reg_ids,
+       data=data,
+       collapse_key='uptoyou',
+       delay_while_idle=True,
+       time_to_live=3600
+   )
+
+   # Downstream message which contains data and notification sections 
+   # using JSON request with extra arguments
+   notification = {
+      "title": "Awesome App Update",
+      "body": "Tap here to start the update!",
+      "icon": "myicon"
+   }
+   res = gcm.json_request(
+       registration_ids=reg_ids,
+       data=data,
+       notification=notification,
+       collapse_key='uptoyou',
+       delay_while_idle=True,
+       time_to_live=3600
    )
 
    # Topic Messaging

--- a/examples/json_request.py
+++ b/examples/json_request.py
@@ -12,12 +12,18 @@ registration_ids = ["your token 1", "your token 2"]
 
 notification = {
     "title": "Awesome App Update",
-    "message": "Tap here to start the update!",
-    "uri": "market://details?id=gcm.play.android.samples.com.gcmquickstart"
+    "body": "Tap here to start the update!",
+    "icon": "myicon"
+}
+
+data = {
+    "Nick": "Mario",
+    "Room": "PortugalVSDenmark"
 }
 
 response = gcm.json_request(registration_ids=registration_ids,
-                            data=notification,
+                            notification=notification,
+                            data=data,
                             collapse_key='awesomeapp_update',
                             restricted_package_name="gcm.play.android.samples.com.gcmquickstart",
                             priority='high',

--- a/gcm/test.py
+++ b/gcm/test.py
@@ -23,6 +23,11 @@ class GCMTest(unittest.TestCase):
             'param1': '1',
             'param2': '2'
         }
+        self.notification = {
+           "title": "Awesome App Update",
+           "body": "Tap here to start the update!",
+           "icon": "myicon"
+        }
         self.response = {
             'results': [
                 {'error': 'InvalidRegistration'},
@@ -91,11 +96,13 @@ class GCMTest(unittest.TestCase):
 
     def test_json_payload(self):
         reg_ids = ['12', '145', '56']
-        json_payload = self.gcm.construct_payload(registration_ids=reg_ids, data=self.data)
+        json_payload = self.gcm.construct_payload(registration_ids=reg_ids, data=self.data,
+            notification=self.notification)
         payload = json.loads(json_payload)
 
         self.assertIn('registration_ids', payload)
         self.assertEqual(payload['data'], self.data)
+        self.assertEqual(payload['notification'], self.notification)
         self.assertEqual(payload['registration_ids'], reg_ids)
 
     def test_plaintext_payload(self):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='python-gcm',
-    version='0.3',
+    version='0.4',
     packages=['gcm'],
     license='The MIT License (MIT)',
     author='Nam Ngo',

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(
     long_description=open('README.rst').read(),
     keywords='android gcm push notification google cloud messaging',
     install_requires=['requests'],
-    tests_require=['mock'],
+    tests_require=['mock', 'coverage'],
     test_suite='gcm.test',
 )


### PR DESCRIPTION

       - GCM also supports notification section where server
         can send notification. This notification can be
         automatically handled by the Android system.
         Notification example:
          notification = {
            "title": "Awesome App Update",
            "body": "Tap here to start the update!",
            "icon": "myicon"
          }

Also updated unit test cases.

here is reference for message format: https://developers.google.com/cloud-messaging/concept-options
