### PR TITLE
Add python version classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,4 +14,12 @@ setup(
     install_requires=['requests'],
     tests_require=['mock', 'coverage'],
     test_suite='gcm.test',
+    classifiers=(
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ),
 )


### PR DESCRIPTION
Make it easy to pragmatically determine this supports python3 via
https://github.com/brettcannon/caniusepython3.

caniusepython3 is formally recommended by
https://docs.python.org/3/howto/pyporting.html